### PR TITLE
Deactivate python env activation in terminal

### DIFF
--- a/settings/vs-code/VSCode-settings.json
+++ b/settings/vs-code/VSCode-settings.json
@@ -45,6 +45,8 @@
   "prettier.documentSelectors": ["**/*.astro"],
   "prettier.printWidth": 120,
   "prettier.singleQuote": true,
+  "python.createEnvironment.trigger": "off",
+  "python.terminal.activateEnvironment": false,
   "redhat.telemetry.enabled": false,
   "security.workspace.trust.untrustedFiles": "open",
   "telemetry.telemetryLevel": "off",


### PR DESCRIPTION
The Python language support extension behaves weirdly with `pyenv` on a new shell session.